### PR TITLE
Fix/property parser false positives

### DIFF
--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/logparser/PropertyParser.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/logparser/PropertyParser.java
@@ -29,8 +29,9 @@ import org.slf4j.LoggerFactory;
 public class PropertyParser {
 
   private static final Logger log = LoggerFactory.getLogger(PropertyParser.class);
-  private static final String MAGIC_SEARCH_STRING = ".*SPINNAKER_PROPERTY_";
-  private static final Pattern MAGIC_SEARCH_PATTERN = Pattern.compile(MAGIC_SEARCH_STRING);
+  private static final String MAGIC_SEARCH_STRING = "SPINNAKER_PROPERTY_";
+  private static final Pattern MAGIC_SEARCH_PATTERN =
+      Pattern.compile("^\\s*" + MAGIC_SEARCH_STRING);
   private static final String MAGIC_JSON_SEARCH_STRING = "SPINNAKER_CONFIG_JSON=";
   private static final Pattern MAGIC_JSON_SEARCH_PATTERN =
       Pattern.compile("^\\s*" + MAGIC_JSON_SEARCH_STRING);


### PR DESCRIPTION
Fixes false positives in build log parsing due to `SPINNAKER_PROPERTY` not being at the start of the line and adds additional tests for these cases.

Example where build logs include the script statements before the outputs that will cause false positive matches:

```
[32;1m$ echo "SPINNAKER_PROPERTY_HELLO_WORLD=ello world"[0;m
SPINNAKER_PROPERTY_HELLO_WORLD=ello world
```

Example screenshot from unit tests showing current implementation will grab false positives and create keys with bad chars:

![2022-01-28 17_56_15-igor – PropertyParserTest groovy  igor igor-monitor-travis test](https://user-images.githubusercontent.com/7676659/151638316-3ba48b93-ebac-4edd-95ae-f053a1b4dea3.png)

This PR fixes these issues.